### PR TITLE
Move binaryName to BuildArchitecture

### DIFF
--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -334,7 +334,8 @@ public static class BuildProject
 
         // Generate build path.
         string buildPath = GenerateBuildPath(BuildSettings.basicSettings.buildPath, releaseType, platform, architecture, distribution, buildTime);
-        string exeName = string.Format(platform.binaryNameFormat, SanitizeFileName(releaseType.productName));
+        string productNameForBin = string.IsNullOrEmpty(releaseType.binaryNameOverride) ? releaseType.productName : releaseType.binaryNameOverride;
+        string binName = string.Format(architecture.binaryNameFormat, SanitizeFileName(productNameForBin));
 
         // Save current user defines, and then set target defines.
         string preBuildDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(platform.targetGroup);
@@ -377,11 +378,11 @@ public static class BuildProject
 
         string error = "";
 #if UNITY_2018_1_OR_NEWER
-        UnityEditor.Build.Reporting.BuildReport buildReport = BuildPipeline.BuildPlayer(releaseType.sceneList.GetSceneFileList(), Path.Combine(buildPath, exeName), architecture.target, options);
+        UnityEditor.Build.Reporting.BuildReport buildReport = BuildPipeline.BuildPlayer(releaseType.sceneList.GetSceneFileList(), Path.Combine(buildPath, binName), architecture.target, options);
         if (buildReport.summary.result == UnityEditor.Build.Reporting.BuildResult.Failed)
             error = buildReport.summary.totalErrors + " occurred.";
 #else
-        error = BuildPipeline.BuildPlayer(releaseType.sceneList.GetSceneFileList(), Path.Combine(buildPath, exeName), architecture.target, options);
+        error = BuildPipeline.BuildPlayer(releaseType.sceneList.GetSceneFileList(), Path.Combine(buildPath, binName), architecture.target, options);
 #endif
         if (!string.IsNullOrEmpty(error))
         {

--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -334,8 +334,7 @@ public static class BuildProject
 
         // Generate build path.
         string buildPath = GenerateBuildPath(BuildSettings.basicSettings.buildPath, releaseType, platform, architecture, distribution, buildTime);
-        string productNameForBin = string.IsNullOrEmpty(releaseType.binaryNameOverride) ? releaseType.productName : releaseType.binaryNameOverride;
-        string binName = string.Format(architecture.binaryNameFormat, SanitizeFileName(productNameForBin));
+        string binName = string.Format(architecture.binaryNameFormat, SanitizeFileName(releaseType.productName));
 
         // Save current user defines, and then set target defines.
         string preBuildDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(platform.targetGroup);

--- a/Editor/Build/Platform/BuildAndroid.cs
+++ b/Editor/Build/Platform/BuildAndroid.cs
@@ -24,14 +24,13 @@ public class BuildAndroid : BuildPlatform
     public override void Init()
     {
         platformName = _name;
-        binaryNameFormat = _binaryNameFormat;
         dataDirNameFormat = _dataDirNameFormat;
         targetGroup = _targetGroup;
 
         if (architectures == null || architectures.Length == 0)
         {
             architectures = new BuildArchitecture[] {
-                new BuildArchitecture(BuildTarget.Android, "Android", true)
+                new BuildArchitecture(BuildTarget.Android, "Android", true, _binaryNameFormat)
             };
         }
         if (variants == null || variants.Length == 0)

--- a/Editor/Build/Platform/BuildArchitecture.cs
+++ b/Editor/Build/Platform/BuildArchitecture.cs
@@ -10,12 +10,14 @@ public class BuildArchitecture
     public BuildTarget target;
     public string name;
     public bool enabled;
+    public string binaryNameFormat;
 
-    public BuildArchitecture(BuildTarget target, string name, bool enabled)
+    public BuildArchitecture(BuildTarget target, string name, bool enabled, string binaryNameFormat)
     {
         this.target = target;
         this.name = name;
         this.enabled = enabled;
+        this.binaryNameFormat = binaryNameFormat;
     }
 }
 

--- a/Editor/Build/Platform/BuildIOS.cs
+++ b/Editor/Build/Platform/BuildIOS.cs
@@ -25,14 +25,13 @@
 //    public override void Init()
 //    {
 //        platformName = _name;
-//        binaryNameFormat = _binaryNameFormat;
 //        dataDirNameFormat = _dataDirNameFormat;
 //        targetGroup = _targetGroup;
 
 //        if (architectures == null || architectures.Length == 0)
 //        {
 //            architectures = new BuildArchitecture[] { 
-//                new BuildArchitecture(BuildTarget.iOS, "iOS", true)
+//                new BuildArchitecture(BuildTarget.iOS, "iOS", true, _binaryNameFormat)
 //            };
 //        }
 //        if (variants == null || variants.Length == 0)

--- a/Editor/Build/Platform/BuildLinux.cs
+++ b/Editor/Build/Platform/BuildLinux.cs
@@ -9,7 +9,6 @@ public class BuildLinux : BuildPlatform
     #region Constants
 
     private const string _name = "Linux";
-    private const string _binaryNameFormat = "{0}.x86";
     private const string _dataDirNameFormat = "{0}_Data";
     private const BuildTargetGroup _targetGroup = BuildTargetGroup.Standalone;
 
@@ -24,17 +23,21 @@ public class BuildLinux : BuildPlatform
     public override void Init()
     {
         platformName = _name;
-        binaryNameFormat = _binaryNameFormat;
         dataDirNameFormat = _dataDirNameFormat;
         targetGroup = _targetGroup;
 
         if (architectures == null || architectures.Length == 0)
         {
-            architectures = new BuildArchitecture[] { 
-                new BuildArchitecture(BuildTarget.StandaloneLinuxUniversal, "Linux Universal", true),
-                new BuildArchitecture(BuildTarget.StandaloneLinux, "Linux x86", false),
-                new BuildArchitecture(BuildTarget.StandaloneLinux64, "Linux x64", false)
+            architectures = new BuildArchitecture[] {
+                new BuildArchitecture(BuildTarget.StandaloneLinuxUniversal, "Linux Universal", true, "{0}"),
+                new BuildArchitecture(BuildTarget.StandaloneLinux, "Linux x86", false, "{0}.x86"),
+                new BuildArchitecture(BuildTarget.StandaloneLinux64, "Linux x64", false, "{0}.x86_64")
             };
+            
+#if UNITY_2018_3_OR_NEWER
+            architectures[0].enabled = false;
+            architectures[2].enabled = true;
+#endif
         }
     }
 }

--- a/Editor/Build/Platform/BuildOSX.cs
+++ b/Editor/Build/Platform/BuildOSX.cs
@@ -24,7 +24,6 @@ public class BuildOSX : BuildPlatform
     public override void Init()
     {
         platformName = _name;
-        binaryNameFormat = _binaryNameFormat;
         dataDirNameFormat = _dataDirNameFormat;
         targetGroup = _targetGroup;
 
@@ -32,11 +31,11 @@ public class BuildOSX : BuildPlatform
         {
             architectures = new BuildArchitecture[] { 
 #if UNITY_2017_3_OR_NEWER
-                new BuildArchitecture(BuildTarget.StandaloneOSX, "OSX", true),
+                new BuildArchitecture(BuildTarget.StandaloneOSX, "OSX", true, _binaryNameFormat),
 #else
-                new BuildArchitecture(BuildTarget.StandaloneOSXUniversal, "OSX Universal", true),
-                new BuildArchitecture(BuildTarget.StandaloneOSXIntel, "OSX Intel", false),
-                new BuildArchitecture(BuildTarget.StandaloneOSXIntel64, "OSX Intel64", false)
+                new BuildArchitecture(BuildTarget.StandaloneOSXUniversal, "OSX Universal", true, _binaryNameFormat),
+                new BuildArchitecture(BuildTarget.StandaloneOSXIntel, "OSX Intel", false, _binaryNameFormat),
+                new BuildArchitecture(BuildTarget.StandaloneOSXIntel64, "OSX Intel64", false, _binaryNameFormat)
 #endif
             };
         }

--- a/Editor/Build/Platform/BuildPC.cs
+++ b/Editor/Build/Platform/BuildPC.cs
@@ -24,15 +24,14 @@ public class BuildPC : BuildPlatform
     public override void Init()
     {
         platformName = _name;
-        binaryNameFormat = _binaryNameFormat;
         dataDirNameFormat = _dataDirNameFormat;
         targetGroup = _targetGroup;
 
         if (architectures == null || architectures.Length == 0)
         {
             architectures = new BuildArchitecture[] { 
-                new BuildArchitecture(BuildTarget.StandaloneWindows, "Windows x86", true),
-                new BuildArchitecture(BuildTarget.StandaloneWindows64, "Windows x64", false)
+                new BuildArchitecture(BuildTarget.StandaloneWindows, "Windows x86", true, _binaryNameFormat),
+                new BuildArchitecture(BuildTarget.StandaloneWindows64, "Windows x64", false, _binaryNameFormat)
             };
         }
     }

--- a/Editor/Build/Platform/BuildPlatform.cs
+++ b/Editor/Build/Platform/BuildPlatform.cs
@@ -13,7 +13,6 @@ public class BuildPlatform
     public BuildVariant[] variants = new BuildVariant[0];
 
     public string platformName;
-    public string binaryNameFormat;
     public string dataDirNameFormat;
     public BuildTargetGroup targetGroup;
     

--- a/Editor/Build/Platform/BuildWebGL.cs
+++ b/Editor/Build/Platform/BuildWebGL.cs
@@ -24,14 +24,13 @@ public class BuildWebGL : BuildPlatform
     public override void Init()
     {
         platformName = _name;
-        binaryNameFormat = _binaryNameFormat;
         dataDirNameFormat = _dataDirNameFormat;
         targetGroup = _targetGroup;
 
         if (architectures == null || architectures.Length == 0)
         {
             architectures = new BuildArchitecture[] { 
-                new BuildArchitecture(BuildTarget.WebGL, "WebGL", true),
+                new BuildArchitecture(BuildTarget.WebGL, "WebGL", true, _binaryNameFormat),
             };
         }
     }

--- a/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
+++ b/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
@@ -38,7 +38,6 @@ public class BuildReleaseTypeDrawer : PropertyDrawer
 
             EditorGUILayout.PropertyField(property.FindPropertyRelative("bundleIndentifier"));
             EditorGUILayout.PropertyField(property.FindPropertyRelative("productName"));
-            EditorGUILayout.PropertyField(property.FindPropertyRelative("binaryNameOverride"), new GUIContent("Binary Name Override", "This will replace the product name in the binary file names"));
             EditorGUILayout.PropertyField(property.FindPropertyRelative("companyName"));
 
             GUILayout.Space(20);

--- a/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
+++ b/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
@@ -38,6 +38,7 @@ public class BuildReleaseTypeDrawer : PropertyDrawer
 
             EditorGUILayout.PropertyField(property.FindPropertyRelative("bundleIndentifier"));
             EditorGUILayout.PropertyField(property.FindPropertyRelative("productName"));
+            EditorGUILayout.PropertyField(property.FindPropertyRelative("binaryNameOverride"), new GUIContent("Binary Name Override", "This will replace the product name in the binary file names"));
             EditorGUILayout.PropertyField(property.FindPropertyRelative("companyName"));
 
             GUILayout.Space(20);


### PR DESCRIPTION
This will allow us to have specific binary file name per architecture and it fixes issues on Linux, which name currently default to x86, no matter the architecture. (cf. #39)