### PR TITLE
Improve handling of BuildOptions

### DIFF
--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -29,7 +29,7 @@ public static class BuildProject
         PerformBuild(buildConfigs);
     }
 
-    public static void BuildSingle(string keyChain, BuildOptions options = BuildOptions.None)
+    public static void BuildSingle(string keyChain, BuildOptions options)
     {
         string[] buildConfigs = new string[] { keyChain };
         PerformBuild(buildConfigs, options);
@@ -324,13 +324,8 @@ public static class BuildProject
     {
         bool success = true;
 
-        // Get build options.
-        if (releaseType.developmentBuild)
-            options |= BuildOptions.Development;
-        if (releaseType.allowDebugging)
-            options |= BuildOptions.AllowDebugging;
-        if (releaseType.enableHeadlessMode)
-            options |= BuildOptions.EnableHeadlessMode;
+        if (options == BuildOptions.None)
+            options = releaseType.buildOptions;
 
         // Generate build path.
         string buildPath = GenerateBuildPath(BuildSettings.basicSettings.buildPath, releaseType, platform, architecture, distribution, buildTime);

--- a/Editor/Build/Settings/BuildReleaseType.cs
+++ b/Editor/Build/Settings/BuildReleaseType.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using UnityEditor;
+
 namespace SuperSystems.UnityBuild
 {
 
@@ -10,9 +11,7 @@ public class BuildReleaseType
     public string companyName = string.Empty;
     public string productName = string.Empty;
 
-    public bool developmentBuild = false;
-    public bool allowDebugging = false;
-    public bool enableHeadlessMode = false;
+    public BuildOptions buildOptions;
     public string customDefines = string.Empty;
 
     public SceneList sceneList = new SceneList();

--- a/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
+++ b/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
@@ -45,21 +45,27 @@ public class BuildReleaseTypeDrawer : PropertyDrawer
 
             EditorGUILayout.PropertyField(property.FindPropertyRelative("customDefines"));
 
-            SerializedProperty developmentBuild = property.FindPropertyRelative("developmentBuild");
-            SerializedProperty allowDebugging = property.FindPropertyRelative("allowDebugging");
-            SerializedProperty enableHeadlessMode = property.FindPropertyRelative("enableHeadlessMode");
+            SerializedProperty buildOptions = property.FindPropertyRelative("buildOptions");
+            
+            bool enableHeadlessMode = ((BuildOptions)buildOptions.intValue & BuildOptions.EnableHeadlessMode) == BuildOptions.EnableHeadlessMode;
+            bool developmentBuild = ((BuildOptions)buildOptions.intValue & BuildOptions.Development) == BuildOptions.Development;
+            bool allowDebugging = ((BuildOptions)buildOptions.intValue & BuildOptions.AllowDebugging) == BuildOptions.AllowDebugging;
+            
+            enableHeadlessMode = EditorGUILayout.ToggleLeft(" Server Build", enableHeadlessMode);
+            if (enableHeadlessMode) buildOptions.intValue |= (int)BuildOptions.EnableHeadlessMode;
+            else buildOptions.intValue &= ~(int)BuildOptions.EnableHeadlessMode;
+            
+            developmentBuild = EditorGUILayout.ToggleLeft(" Development Build", developmentBuild);
+            if (developmentBuild) buildOptions.intValue |= (int)BuildOptions.Development;
+            else buildOptions.intValue &= ~(int)BuildOptions.Development;
 
-            EditorGUI.BeginDisabledGroup(enableHeadlessMode.boolValue);
-            developmentBuild.boolValue = EditorGUILayout.ToggleLeft(" Development Build", developmentBuild.boolValue);
+            EditorGUI.BeginDisabledGroup(!developmentBuild);
+            allowDebugging = EditorGUILayout.ToggleLeft(" Script Debugging", allowDebugging);
             EditorGUI.EndDisabledGroup();
-
-            EditorGUI.BeginDisabledGroup(!developmentBuild.boolValue);
-            allowDebugging.boolValue = EditorGUILayout.ToggleLeft(" Script Debugging", allowDebugging.boolValue);
-            EditorGUI.EndDisabledGroup();
-
-            EditorGUI.BeginDisabledGroup(developmentBuild.boolValue);
-            enableHeadlessMode.boolValue = EditorGUILayout.ToggleLeft(" Headless Mode", enableHeadlessMode.boolValue);
-            EditorGUI.EndDisabledGroup();
+            if (allowDebugging) buildOptions.intValue |= (int)BuildOptions.AllowDebugging;
+            else buildOptions.intValue &= ~(int)BuildOptions.AllowDebugging;
+            
+            buildOptions.intValue = (int)(BuildOptions)EditorGUILayout.EnumFlagsField("Advanced", (BuildOptions)buildOptions.intValue);
 
             EditorGUILayout.PropertyField(property.FindPropertyRelative("sceneList"));
 

--- a/Editor/Build/Settings/UI/ProjectConfigurationsDrawer.cs
+++ b/Editor/Build/Settings/UI/ProjectConfigurationsDrawer.cs
@@ -110,6 +110,7 @@ public class ProjectConfigurationsDrawer : PropertyDrawer
                     BuildPlatform platform;
                     BuildArchitecture arch;
                     BuildDistribution dist;
+                    BuildOptions buildOptions = BuildOptions.None;
 
                     bool parseSuccess = BuildSettings.projectConfigurations.ParseKeychain(selectedKeyChain.stringValue, out releaseType, out platform, out arch, out dist);
 
@@ -123,6 +124,7 @@ public class ProjectConfigurationsDrawer : PropertyDrawer
 
                         if (releaseType != null)
                         {
+                            buildOptions = releaseType.buildOptions;
                             EditorGUILayout.LabelField("Release Type", UnityBuildGUIUtility.midHeaderStyle);
                             EditorGUILayout.LabelField("Type Name:\t" + releaseType.typeName);
                             
@@ -154,20 +156,26 @@ public class ProjectConfigurationsDrawer : PropertyDrawer
                         GUI.backgroundColor = Color.green;
                         if (GUILayout.Button("Build", GUILayout.ExpandWidth(true)))
                         {
+                            BuildOptions finalBuildOptions = buildOptions;
                             EditorApplication.delayCall += () =>
-                                BuildProject.BuildSingle(selectedKeyChain.stringValue);
+                                BuildProject.BuildSingle(selectedKeyChain.stringValue, finalBuildOptions);
                         }
                         if (GUILayout.Button("Build and Run", GUILayout.ExpandWidth(true)))
                         {
+                            buildOptions |= BuildOptions.AutoRunPlayer;
+                            BuildOptions finalBuildOptions = buildOptions;
                             EditorApplication.delayCall += () =>
-                                BuildProject.BuildSingle(selectedKeyChain.stringValue, BuildOptions.AutoRunPlayer);
+                                BuildProject.BuildSingle(selectedKeyChain.stringValue, finalBuildOptions);
                         }
 
-                        EditorGUI.BeginDisabledGroup(!releaseType.developmentBuild);
+                        EditorGUI.BeginDisabledGroup((buildOptions & BuildOptions.Development) != BuildOptions.Development);
                         if (GUILayout.Button("Build and Run w/ Profiler", GUILayout.ExpandWidth(true)))
                         {
+                            buildOptions |= BuildOptions.AutoRunPlayer;
+                            buildOptions |= BuildOptions.ConnectWithProfiler;
+                            BuildOptions finalBuildOptions = buildOptions;
                             EditorApplication.delayCall += () =>
-                                BuildProject.BuildSingle(selectedKeyChain.stringValue, BuildOptions.AutoRunPlayer | BuildOptions.ConnectWithProfiler);
+                                BuildProject.BuildSingle(selectedKeyChain.stringValue, finalBuildOptions);
                         }
                         EditorGUI.EndDisabledGroup();
                         GUI.backgroundColor = defaultBackgroundColor;


### PR DESCRIPTION
Before there were a limited numbers of BuildOptions handled via boolean in the code. An important missing one was the Compression Method for example.

I've changed the logic to remove these bool and instead directly use BuildOptions enum. I've kept the current options displayed (just updated them to mirror the same wording and order as Unity build window), and added an Advanced options where one can set the flags they want for their BuildOptions.

I think this can benefit everyone, so I'd be happy to see it merged. Feel free to take a look at my other branches and merge them as well if you like! (One of them was for allowing the selection of the BuildSettings for example, as I dislike having hard coded resources in my project, and it's a shame to not use the strength of ScriptableObject ;)
cf. https://github.com/rthery/unity-build/branches/yours