### PR TITLE
Remove obsolete Linux build architectures on 2019.2+

### DIFF
--- a/Editor/Build/Platform/BuildLinux.cs
+++ b/Editor/Build/Platform/BuildLinux.cs
@@ -29,17 +29,22 @@ public class BuildLinux : BuildPlatform
         if (architectures == null || architectures.Length == 0)
         {
             architectures = new BuildArchitecture[] {
+                new BuildArchitecture(BuildTarget.StandaloneLinux64, "Linux x64", false, "{0}.x86_64"),
+#if !UNITY_2019_2_OR_NEWER
                 new BuildArchitecture(BuildTarget.StandaloneLinuxUniversal, "Linux Universal", true, "{0}"),
                 new BuildArchitecture(BuildTarget.StandaloneLinux, "Linux x86", false, "{0}.x86"),
-                new BuildArchitecture(BuildTarget.StandaloneLinux64, "Linux x64", false, "{0}.x86_64")
-            };
-            
-#if UNITY_2018_3_OR_NEWER
-            architectures[0].enabled = false;
-            architectures[2].enabled = true;
 #endif
+            };
+
+#if UNITY_2018_3_OR_NEWER
+            architectures[0].enabled = true;
+#endif
+
+#if UNITY_2018_3_OR_NEWER && !UNITY_2019_2_OR_NEWER
+            architectures[1].enabled = false;
+#endif
+            }
         }
     }
-}
 
 }


### PR DESCRIPTION
Fixes #45