### PR TITLE
Add option to sync version with PlayerSettings

### DIFF
--- a/Editor/Build/Settings/ProductParameters.cs
+++ b/Editor/Build/Settings/ProductParameters.cs
@@ -12,6 +12,7 @@ public class ProductParameters
     // $NOUN, $ADJECTIVE, $DAYSSINCE("DATE"), $SECONDS, $BUILDS
     public string version = "1.0.$DAYSSINCE(\"January 1, 2015\").$SECONDS";
     public bool autoGenerate = true;
+    public bool syncWithPlayerSettings = false;
 }
 
 }

--- a/Editor/Build/Settings/UI/ProductParametersDrawer.cs
+++ b/Editor/Build/Settings/UI/ProductParametersDrawer.cs
@@ -24,15 +24,27 @@ public class ProductParametersDrawer : PropertyDrawer
         if (show)
         {
             EditorGUILayout.BeginVertical(UnityBuildGUIUtility.dropdownContentStyle);
+            
+            SerializedProperty autoGenerate = property.FindPropertyRelative("autoGenerate");
+            SerializedProperty syncWithPlayerSettings = property.FindPropertyRelative("syncWithPlayerSettings");
 
+            EditorGUI.BeginDisabledGroup(syncWithPlayerSettings.boolValue);
             EditorGUILayout.PropertyField(property.FindPropertyRelative("version"));
 
             EditorGUI.BeginDisabledGroup(true);
             EditorGUILayout.PropertyField(property.FindPropertyRelative("lastGeneratedVersion"));
             EditorGUI.EndDisabledGroup();
 
-            SerializedProperty autoGenerate = property.FindPropertyRelative("autoGenerate");
             autoGenerate.boolValue = EditorGUILayout.ToggleLeft("Auto-Generate Version", autoGenerate.boolValue);
+            EditorGUI.EndDisabledGroup();
+            
+            EditorGUI.BeginDisabledGroup(autoGenerate.boolValue);
+            syncWithPlayerSettings.boolValue = EditorGUILayout.ToggleLeft("Sync Version with Player Settings", syncWithPlayerSettings.boolValue);
+            EditorGUI.EndDisabledGroup();
+            if (syncWithPlayerSettings.boolValue)
+            {
+                property.FindPropertyRelative("version").stringValue = PlayerSettings.bundleVersion;
+            }
 
             EditorGUILayout.PropertyField(property.FindPropertyRelative("buildCounter"));
 


### PR DESCRIPTION
A small change to add an option to automatically sync the player version settings with UnityBuild