### PR TITLE
Fix for issue #153: Unity 6 'Default' is not a valid subtarget for the Standalone build target

### DIFF
--- a/Editor/Build/Platform/BuildTarget.cs
+++ b/Editor/Build/Platform/BuildTarget.cs
@@ -17,7 +17,7 @@ namespace SuperUnityBuild.BuildTool
             UnityBuildTarget.StandaloneOSX or
             UnityBuildTarget.StandaloneWindows or UnityBuildTarget.StandaloneWindows64;
 
-        public BuildTarget(UnityBuildTarget type, string name, bool enabled, string binaryNameFormat, int subtarget = 0)
+        public BuildTarget(UnityBuildTarget type, string name, bool enabled, string binaryNameFormat, int subtarget = 2)
         {
             this.type = type;
             this.name = name;


### PR DESCRIPTION
Simply replaced the default value of subtarget with 2 (Player). Was originally 0 (Default).